### PR TITLE
게임 종료 send, matchNum 오류 수정

### DIFF
--- a/Server/server.cpp
+++ b/Server/server.cpp
@@ -13,6 +13,7 @@
 
 CRITICAL_SECTION cs;
 HANDLE hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+int deleteThreadNum = -1;
 
 typedef struct Player {
   int x, y;
@@ -103,9 +104,6 @@ void CheckPlayerBulletCollisions(int matchNum);
 void CheckPlayersCollisions(int matchNum);
 void updateSendParam(int matchNum);
 
-// bullet -> senparam::bullet 복사 함수?
-void copyBullet() {}
-
 // 매치를 삭제하는 함수
 void closeSocketFunc(SOCKET client_sock, char matchNum, char playerNum) {
   // 디버그용 출력
@@ -122,9 +120,11 @@ void closeSocketFunc(SOCKET client_sock, char matchNum, char playerNum) {
     g_matches[i].matchNum = i;
   }
 
+  deleteThreadNum = matchNum;
   // 바꾼 matchNum을 다른 스레드에도 적용시켜야함
   // -> 각 recv스레드에서 반복문이 시작될 때 자신의 매치 번호를 검사한다
 }
+
 
 // 클라이언트와 데이터 통신
 DWORD WINAPI RecvProcessClient(LPVOID arg) {
@@ -172,9 +172,12 @@ DWORD WINAPI RecvProcessClient(LPVOID arg) {
       err_display("recv()");
       closeSocketFunc(client_sock, matchNum, playerNum);
       SetEvent(hEvent);
+      ExitThread(0);
       break;
     } else if (retval == 0) {
+      //closeSocketFunc(client_sock, matchNum, playerNum);
       SetEvent(hEvent);
+      //ExitThread(0);
       break;
     }
 
@@ -206,7 +209,7 @@ DWORD WINAPI RecvProcessClient(LPVOID arg) {
       g_matches[matchNum].p2 = buf[0];
       printf("[%s:%d] %c\n", addr, ntohs(clientaddr.sin_port),
              g_matches[matchNum].p2);
-    }
+    } 
 
     if (retval == SOCKET_ERROR) {
       err_display("send()");
@@ -252,6 +255,13 @@ DWORD WINAPI timerProcessClient(LPVOID lpParam) {
       printf("타이머 대기 실패 또는 중단: %d\n", GetLastError());
       break;
     }
+
+    EnterCriticalSection(&cs);
+    if (deleteThreadNum == matchNum) {
+      deleteThreadNum = -1;
+      ExitThread(0);
+    }
+    LeaveCriticalSection(&cs);
     // 벡터의 유효한 범위 내에서, 현재 매치 번호와, 매치[현재 매치번호]의 매치
     // 번호가 일치하는 지 비교한다, 다르다면 감소
     while (!(matchNum < 0) && matchNum < g_matches.size() &&
@@ -269,25 +279,46 @@ DWORD WINAPI timerProcessClient(LPVOID lpParam) {
     applyGravity(matchNum);
     movePlayer(matchNum);
     if (int isNext = IsNextColliding(matchNum)) {  // 1(p1), 2(p2)를 리턴하면 조건문 진입
-      if (g_matches[matchNum].mapNum == 1) {
+      // p1이 이기면 score+=10, p2가 이기면 score+=1
+      if (isNext == 1)
+        g_matches[matchNum].score += 10;
+      else if (isNext == 2)
+        g_matches[matchNum].score += 1;
+      // 추후 수정
+     
+      // mapNum 3 -> 4 게임종료, ### mapNum == 4이면 게임 종료로 판단?
+      // 비정상 종료를 몰수승으로 판단하면 게임 종료 시에는 반드시 map_num = 4인
+      // 상태로 게임 종료
+      // -> CHANGE_MAP 패킷의 mapNum으로 게임 종료, 승 패를 알림
+      // 클라이언트에 보낼때는 5와 6을 나눠서 보냄, 5는승리, 6은 패배
+      // 서버 입장에서 5는 p1승, 6은 p2승
+      if (g_matches[matchNum].mapNum == 3 &&
+               g_matches[matchNum].score >= 10) {
+        g_matches[matchNum].mapNum = 5;
+      }
+      else if (g_matches[matchNum].mapNum == 3 &&
+               g_matches[matchNum].score < 10) {
+        g_matches[matchNum].mapNum = 6;
+      }
+      else if (g_matches[matchNum].mapNum == 1) {
+        g_matches[matchNum].mapNum = 2;
+        //printf("이동한 맵 넘버: %d\n", g_matches[matchNum].mapNum);
         InitMap(matchNum, map1);
       } 
       else if (g_matches[matchNum].mapNum == 2) {
+        g_matches[matchNum].mapNum = 3;
         InitMap(matchNum, map2);
       }
+   
       DeleteAllEnemies(matchNum);
       DeleteAllBullets(matchNum);
       DeleteAllItems(matchNum);
       initPlayer(matchNum);
       initEnemy(matchNum);
       initItem(matchNum);
-      // p1이 이기면 score+=10, p2가 이기면 score+=1
-      if (isNext == 1)
-        g_matches[matchNum].score+=10;
-      else if (isNext == 2)
-        g_matches[matchNum].score+=1;
-      // 추후 수정
-      g_matches[matchNum].header = true;
+      
+      g_matches[matchNum].header = true; 
+
     }
     else {
       moveBullets(matchNum);
@@ -349,7 +380,16 @@ DWORD WINAPI timerProcessClient(LPVOID lpParam) {
       else {
         sendParam::MapInfoPacket mapInfoPacket;
         sendSize = sizeof(sendParam::MapInfoPacket);
-        mapInfoPacket.info.mapNum = g_matches[matchNum].mapNum;
+        // p1 승일때
+        if (g_matches[matchNum].mapNum == 5) {
+          if (i == 0) mapInfoPacket.info.mapNum = 5;
+          else if (i == 1) mapInfoPacket.info.mapNum = 6;
+        }// 수정
+        else if (g_matches[matchNum].mapNum == 6) {
+          if (i == 0) mapInfoPacket.info.mapNum = 6;
+          else if (i == 1) mapInfoPacket.info.mapNum = 5;
+        }
+        else mapInfoPacket.info.mapNum = g_matches[matchNum].mapNum;
         memcpy(sendBuf, &mapInfoPacket, sendSize);
         int retval = send(g_matches[matchNum].client_sock[i], sendBuf, sendSize, 0);
         if (retval == SOCKET_ERROR) {


### PR DESCRIPTION
1. 승패(게임종료)
원래 map_num으로 게임 종료를 판정함 -> 승패도 map_num을 이용해도 문제없다고 판단
CHANGE_MAP 패킷으로 보냄
<서버에서> mapNum이 5면 p1승, mapNum이 6이면 p2승
<클라에서> map_num이 5면 내가 승리, map_num이 6이면 내가 패배

-> PLAYER_INFO와 같이 클라이언트 1, 2에게 보내는 mapNum을 다르게 해서 플레이어 구분

2. 매치 넘버가 뒤섞이는 듯한 문제(추정)
MATCH는 삭제했지만 매치 내부 스레드는 삭제되지 않음
-> 스레드 자살 코드 추가
테스트 아직

스레드 자살 단계
1. 플레이어n의 recv 문제 -> closeSocektFunc호출 -> 해당 스레드 자살
2. closeSocketFunc에서 매치 삭제 + deleteRecvThreadNum, deleteTimerThreadNum을 수정
3. 남은 recv스레드, timer스레드에서 matchNum과 위의 변수를 비교해서 자살

***현재 코드는 recv 스레드가 하나 남음, 테스트 후 문제 없으면 deleteRecvThreadNum 추가***
위 과정은 matchNum과 g_matches[matchNum].matchNum의 비교 전에 작동

문제점: 매치0 스레드가 삭제되기 전에 매치1 스레드만 두 번 연속 실행될 경우 매치 1스레드가 삭제될 수 있음